### PR TITLE
Update to GP capability

### DIFF
--- a/test/lib/gp-test.js
+++ b/test/lib/gp-test.js
@@ -36,6 +36,31 @@ if(localCredsFile) {
     }
 }
 
+/**
+ * Acceptable source language.
+ */
+module.exports.SOURCES = [ 'en' ];
+
+/**
+ * Acceptable target languages.
+ */
+module.exports.TARGETS = [ 'it', 'ko' ];
+
+/**
+ * Pseudo language doing Cyrillic transliteration
+ */
+module.exports.CYRILLIC = 'qru';
+
+/**
+ * Language not covered by translation, yet
+ */
+module.exports.KLINGON = 'tlh';
+
+/**
+ * Language that always fails
+ */
+module.exports.NOLANG = 'zxx';
+
 var VERBOSE=false;
 
 module.exports.getCredentials = function getCredentials() {


### PR DESCRIPTION
* Updated test script for uploading resource strings with a language ID not supported by MT. Also added a test case for uploading strings with an invalid language ID.
* remove 'es' from default list
* Make source/target langs parameterized.
* verify both value and sourceValue

Author:    Yoshito Umaoka <yoshito_umaoka@us.ibm.com>
Author:    Steven R. Loomis <srloomis@us.ibm.com>

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/22