### PR TITLE
add bundle.getBundleInfo alias

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -505,7 +505,6 @@ Bundle.prototype.create = function createBundle(body, cb) {
 Bundle.prototype.getInfoFields = new utils.Fields(["translationStatusMetricsByLanguage",
                                   "reviewStatusMetricsByLanguage",
                                   "partnerStatusMetricsByLanguage"]);
-
 /**
  * Get bundle info
  * @param {Object} opts - Options object
@@ -538,6 +537,12 @@ Bundle.prototype.getInfo = function getBundleInfo(opts, cb) {
        }
      });
 };
+
+/**
+ * Alias.
+ * @ignore
+ */
+Bundle.prototype.getBundleInfo = Bundle.prototype.getInfo;
 
 /**
  * Callback returned by Bundle~getInfo(). 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -308,6 +308,18 @@ describe('gaasClient.bundle()', function() {
         done();
     });
   });
+  it('Should be able to use swagger function getBundleInfo', function(done) {
+    var bundle = gaasClient.bundle({id:projectId, serviceInstance: instanceName});
+    expect(bundle.sourceLanguage).to.not.be.ok;
+    bundle.getBundleInfo({}, function(err, bundle2) {
+        if(err) return done(err); // not ok
+        expect(bundle2).to.be.ok;
+        expect(bundle2.updatedBy).to.be.a('string');
+        expect(bundle2.updatedAt).to.be.a('date');
+        expect(bundle2.sourceLanguage).to.equal(gaasTest.SOURCES[0]);
+        done();
+    });
+  });
   it('should now let me call bundles() and see our bundle', function(done) {
     gaasClient.bundles({serviceInstance: instanceName}, function(err, list) {
         if(err) return done(err);


### PR DESCRIPTION
As the bug noted, bundle.getBundleInfo should work as an alias for bundle.getInfo

No doc impact as this is not the preferred function name.

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/26