### PR TITLE
doc: bump dependency, regen doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "g11n-pipeline",
-  "version": "1.2.3",
+  "version": "1.3.0-0",
   "description": "JavaScript (Node.js, etc) client for Bluemix Globalization Pipeline",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coveralls": "^2.11.12",
     "github-markdown-css": "^2.2.0",
     "istanbul": "^0.4.1",
-    "jsdoc-to-markdown": "^1.3.3",
+    "jsdoc-to-markdown": "^2.0.1",
     "marked": "^0.3.5",
     "mocha": "^2.2.5",
     "nyc": "^8.1.0",

--- a/template-README.md
+++ b/template-README.md
@@ -9,6 +9,8 @@ with Bluemix applications translated into the languages in which they work.
 This SDK currently supports [Node.js](http://nodejs.org).
 
 [![npm version](https://badge.fury.io/js/g11n-pipeline.svg)](https://badge.fury.io/js/g11n-pipeline)
+[![Build Status](https://travis-ci.org/IBM-Bluemix/gp-js-client.svg?branch=master)](https://travis-ci.org/IBM-Bluemix/gp-js-client)
+[![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-js-client/badge.svg)](https://coveralls.io/github/IBM-Bluemix/gp-js-client)
 
 ## Sample
 


### PR DESCRIPTION
* bump jsdoc-to-markdown to 2.0.1 (was broken)
* fix missed stuff in the template