### PR TITLE
Add /rest instead of dropping it from the URL

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -162,7 +162,7 @@ Client.prototype.ready = function ready(arg, cb) {
     cb(null, arg, this.swaggerClient.apis);
   } else {
     var credentials = this._options.credentials;
-    var schemaUrl = this._schemaUrl =  this._options.credentials.url + '/rest/swagger.json';
+    var schemaUrl = this._schemaUrl =  this._options.credentials.url + '/swagger.json';
     if(debugREST) /*istanbul ignore next*/ console.log('.. fetching ' + schemaUrl);
     
     var authorizations;
@@ -1159,7 +1159,7 @@ var debugREST = false;
  */
 exports._normalizeUrl = function _normalizeUrl(u) {
   u = removeTrailing(u,"/"); // take off the trailing slash
-  u = removeTrailing(u,"/rest"); // take off the trailing /rest
+  u = addTrailing(u,"/rest"); // add the trailing /rest
   return u;
 }
 
@@ -1173,10 +1173,27 @@ function removeTrailing(str, chr) {
   if (!str || (str=="")) return str;
   var newIdx = str.length-chr.length;
   if(newIdx < 0) return str;
-  if (str.substring(newIdx, str.length) == chr) {
+  if (str.substring(newIdx, str.length) === chr) {
     return str.substring(0, newIdx);
   } else {
     return str;
+  }
+};
+
+/**
+ * Add trailing text from a string
+ * @param {string} str - Input string
+ * @param {string} chr - Text to be added (ignored if already present)
+ * @ignore
+ */
+function addTrailing(str, chr) {
+  if (!str || (str=="")) return str;
+  var newIdx = str.length-chr.length;
+  if(newIdx < 0) return str;
+  if (str.substring(newIdx, str.length) === chr) {
+    return str; // already there
+  } else {
+    return str+chr; // append
   }
 };
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -1,5 +1,5 @@
 /*	
- * Copyright IBM Corp. 2015,2016
+ * Copyright IBM Corp. 2015,2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ var urlEnv = gaas._normalizeUrl(opts.credentials.url); // use GaaS normalize
   
 describe('Setting up GaaS test', function() {
   if ( urlEnv ) {
-    var urlToPing = urlEnv+'/';
+    var urlToPing = urlEnv.replace(/\/rest.*$/,'/');
     if(VERBOSE) console.dir(urlToPing);
     it('should let us directly ping ' + urlToPing, function(done) {
       var timeout;
@@ -1214,14 +1214,14 @@ describe('gaasClient.bundle()', function() {
   // if(opts.credentials.isAdmin) {
  
     
-    gaasTest.expectCORSURL(urlEnv + '/rest/swagger.json',
+    gaasTest.expectCORSURL(urlEnv + '/swagger.json',
                         null, ' noauth');
                         
-    gaasTest.expectCORSURL(urlEnv + '/rest/swagger.json',
+    gaasTest.expectCORSURL(urlEnv + '/swagger.json',
                         myAuth, ' reader');
   
     // hardcoded URL here..
-    gaasTest.expectCORSURL(urlEnv + '/rest/' + instanceName + '/v2/bundles/'+projectId3+'/qru',
+    gaasTest.expectCORSURL(urlEnv + '/' + instanceName + '/v2/bundles/'+projectId3+'/qru',
                         myAuth, ' reader');
   
     // // this should authenticate but NOT be CORS
@@ -1236,14 +1236,14 @@ describe('gaasClient.bundle()', function() {
       myHmac.apply(opts);
     };
   
-    gaasTest.expectCORSURL(urlEnv + '/rest/swagger.json',
+    gaasTest.expectCORSURL(urlEnv + '/swagger.json',
                         myAdminAuth, ' admin');
   
     // hardcoded URL here..
-    gaasTest.expectCORSURL(urlEnv + '/rest/' + instanceName + '/v2/bundles/'+projectId3+'/qru',
+    gaasTest.expectCORSURL(urlEnv + '/' + instanceName + '/v2/bundles/'+projectId3+'/qru',
                         myAdminAuth, ' admin');
     // if(isAdmin) {
-    //   gaasTest.expectNonCORSURL(urlEnv + '/rest/' + instanceName + '/v2/bundles',
+    //   gaasTest.expectNonCORSURL(urlEnv + '/' + instanceName + '/v2/bundles',
     //                       myAdminAuth, ' admin');    
     // }
 

--- a/test/rest-test.js
+++ b/test/rest-test.js
@@ -1,5 +1,5 @@
 /*	
- * Copyright IBM Corp. 2015
+ * Copyright IBM Corp. 2015,2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,9 @@ var sourceData = {
 if ( ! url ) {
   url = gaasClient._getUrl(); // fetch the URL
 }
+
+// Trim off /rest here, so that we are working with the top level url
+url = url.replace(/\/rest.*$/,'');
 
 var http_or_https = require('./lib/byscheme')(url);
 


### PR DESCRIPTION
* improve consistency with other clients.
* historical note:  /rest used to be NOT included in the URL from the GP broker.
(this was in the Experimental version- so a very old change.)
* this affects internal URL usage, and the INTERNAL `_getUrl()` function.

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/56