### PR TITLE
drop v0.12 in v2.0, add "engines" to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This SDK currently supports [Node.js](http://nodejs.org).
 [![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-js-client/badge.svg)](https://coveralls.io/github/IBM-Bluemix/gp-js-client)
 [![Coverity Status](https://img.shields.io/coverity/scan/9399.svg)](https://scan.coverity.com/projects/ibm-bluemix-gp-js-client)
 
+### Upcoming News
+
+* ⚠ Please note that support for Node v0.12 [will be removed by version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
+
 ## Sample
 
 For a working Bluemix application sample,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.5.0-1",
   "description": "JavaScript (Node.js, etc) client for Bluemix Globalization Pipeline",
   "main": "index.js",
+  "engines": {
+    "node": ">=0.12"
+  },
   "scripts": {
     "test": "mocha",
     "coverage": "nyc mocha && nyc report --reporter=lcov",

--- a/template-README.md
+++ b/template-README.md
@@ -13,6 +13,10 @@ This SDK currently supports [Node.js](http://nodejs.org).
 [![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-js-client/badge.svg)](https://coveralls.io/github/IBM-Bluemix/gp-js-client)
 [![Coverity Status](https://img.shields.io/coverity/scan/9399.svg)](https://scan.coverity.com/projects/ibm-bluemix-gp-js-client)
 
+### Upcoming News
+
+* ⚠ Please note that support for Node v0.12 [will be removed by version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
+
 ## Sample
 
 For a working Bluemix application sample,


### PR DESCRIPTION
* announce dropping support for node v0.12
* also, add an `engines` field with value `node ≥ 0.12` for now, to be updated later

Supports: https://github.com/IBM-Bluemix/gp-js-client/issues/55