### PR TITLE
"Hide" the .gp and .swaggerClient properties

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -186,7 +186,9 @@ Client.prototype.ready = function ready(arg, cb) {
       authorizations: authorizations,
       success: function() {
         if(swaggerClient.ready === true) {
-          that.swaggerClient = swaggerClient;
+          Object.defineProperty(that, 'swaggerClient', {
+            configurable: true, enumerable: false, value: swaggerClient, writable: false
+          });
           if(debugREST) /*istanbul ignore next*/ console.log('.. swagger loaded && ready');
           cb(null, arg, that.apis());
         } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,9 @@ const copyProps = module.exports.copyProps = function copyProps(o, props) {
  */
 const initSubObject = module.exports.initSubObject = function initSubObject(o, gp, props) {
   copyProps(o, props);
-  o.gp = gp; // actually Client
+  Object.defineProperty(o, 'gp', {
+    configurable: true, enumerable: false, value: gp, writable: false
+  });
   o.serviceInstance = gp.getServiceInstance(o); // get the service instance ID
 };
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -174,6 +174,43 @@ describe('Verifying again that we can reach the server', function() {
   });
 });
 
+describe('Verify client.swaggerClient and *.gp are hidden', function () {
+  it('Should verify properties on gaasClient', function() {
+    expect(gaasClient).to.be.ok;
+    expect(gaasClient.swaggerClient).to.be.an('object');
+    expect(gaasClient).to.have.a.property('swaggerClient');
+    expect(Object.keys(gaasClient)).to.not.include('swaggerClient');
+  });
+  it('Should verify properties on bundle()', function() {
+    const o = gaasClient.bundle('something');
+    expect(o).to.be.ok;
+    expect(o.gp).to.be.an('object');
+    expect(o).to.have.a.property('gp');
+    expect(Object.keys(o)).to.not.include('gp');
+  });
+  it('Should verify properties on bundle().entry()', function() {
+    const o = gaasClient.bundle('something').entry({resourceKey: 'somethingElse', languageId: 'tlh'});
+    expect(o).to.be.ok;
+    expect(o.gp).to.be.an('object');
+    expect(o).to.have.a.property('gp');
+    expect(Object.keys(o)).to.not.include('gp');
+  });
+  it('Should verify properties on tr()', function() {
+    const o = gaasClient.tr('something');
+    expect(o).to.be.ok;
+    expect(o.gp).to.be.an('object');
+    expect(o).to.have.a.property('gp');
+    expect(Object.keys(o)).to.not.include('gp');
+  });
+  it('Should verify properties on user()', function() {
+    const o = gaasClient.user('something');
+    expect(o).to.be.ok;
+    expect(o.gp).to.be.an('object');
+    expect(o).to.have.a.property('gp');
+    expect(Object.keys(o)).to.not.include('gp');
+  });
+});
+
 describe('gaasClient.supportedTranslations()', function() {
   it('Should let us list translations', function(done) {
     gaasClient.supportedTranslations({}, function(err, translations) {


### PR DESCRIPTION
use `defineProperty` to "hide" these properties. This way `console.dir()` or `Object.keys()` is more useful on the top level client object and other generated objects.  Otherwise, there are various circular references and internal contents exposed. Exposed isn't too bad, but it makes the objects ugly to print out.

```
> console.dir(client.bundle('Something'))
Bundle {
  id: 'Something',
  serviceInstance: 'fefog854b59bc71dbc88eb454f378b8200e354251280' }
> JSON.stringify(client.tr('my-tr-ID'))
'{"id":"my-tr-ID","serviceInstance":"fefog854b59bc71dbc88eb454f378b8200e354251280"}'
```

Note: I _think_ this code should work on v0.12 from docs and my local test, but would be good to make sure travis agrees.  

Fixes #81 