### PR TITLE
Drop support for Node v0.12, begin v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '0.12'
 - '4'
 - '6'
 - '8'

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This SDK currently supports [Node.js](http://nodejs.org).
 [![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-js-client/badge.svg)](https://coveralls.io/github/IBM-Bluemix/gp-js-client)
 [![Coverity Status](https://img.shields.io/coverity/scan/9399.svg)](https://scan.coverity.com/projects/ibm-bluemix-gp-js-client)
 
-### Upcoming News
+### News
 
-* ⚠ Please note that support for Node v0.12 [will be removed by version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
+* ⚠ Please note that support for Node v0.12 [has been dropped in version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
 
 ## Sample
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "g11n-pipeline",
-  "version": "1.5.2-0",
+  "version": "1.6.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "g11n-pipeline",
-  "version": "1.5.2-0",
+  "version": "1.6.0-0",
   "description": "JavaScript (Node.js, etc) client for Bluemix Globalization Pipeline",
   "main": "index.js",
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4"
   },
   "scripts": {
     "test": "mocha",

--- a/template-README.md
+++ b/template-README.md
@@ -13,9 +13,9 @@ This SDK currently supports [Node.js](http://nodejs.org).
 [![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-js-client/badge.svg)](https://coveralls.io/github/IBM-Bluemix/gp-js-client)
 [![Coverity Status](https://img.shields.io/coverity/scan/9399.svg)](https://scan.coverity.com/projects/ibm-bluemix-gp-js-client)
 
-### Upcoming News
+### News
 
-* ⚠ Please note that support for Node v0.12 [will be removed by version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
+* ⚠ Please note that support for Node v0.12 [has been dropped in version 2.0 of this SDK](https://github.com/IBM-Bluemix/gp-js-client/issues/55). See the [Node.js LTS schedule](https://github.com/nodejs/LTS).
 
 ## Sample
 


### PR DESCRIPTION
* bump version to v2.0.0-0
* drop Node v0.12 from travis and package.json

No actual breaking changes here, but get ready.

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/55