### PR TITLE
Remove README.html in prepack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 /coverage
 /.vscode
 /.nyc_output
+*.tgz

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "docs": "jsdoc2md lib/*.js --template template-README.md > README.md",
     "html": "npm run docs && node util/gen-html.js",
     "vscode-typings": "tsd query node mocha chai request --action install",
-    "eslint": "mocha -f eslint --reporter list"
+    "eslint": "mocha -f eslint --reporter list",
+    "prepack": "rm -f README.html"  
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The README.html is a transient file, a pre-rendered version of the README. It should not be included in the npm tarball, as it might be out of date.

README.html is only generated by explicitly calling `npm run html`.

Even though README.html is in `.gitignore`, it is explicitly un-ignored by npm.

- remove README.html in the `prepack` stage
- also ignore the npm tarball in .gitignore

You can test this with `npm run html ; npm pack`. You should see a `g11n-pipeline*.tgz` file that does NOT contain README.html.

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/94