### PR TITLE
fix HMAC requestInterceptor for Swagger 3.3.x

### DIFF
--- a/lib/gp-hmac.js
+++ b/lib/gp-hmac.js
@@ -83,7 +83,7 @@ function rfc1123date(d) {
  */
 GaasHmac.prototype.apply = function(obj) {
   //if(this.VERBOSE) console.dir(obj, {color: true, depth: null});
-  if(obj.url.indexOf("/swagger.json") !== -1) return true; // skip for swagger.json
+  if(obj.url.indexOf("/swagger.json") !== -1) return obj; // skip for swagger.json
   var dateString = (this.forceDateString ||
                     rfc1123date(this.forceDate || new Date()));
   var bodyString = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,11 @@
         "typedarray": "0.0.6"
       }
     },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -4563,12 +4568,13 @@
       "dev": true
     },
     "swagger-client": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.2.2.tgz",
-      "integrity": "sha1-xHDretdPDo56hQ3DjPQaeEIg9oA=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.3.1.tgz",
+      "integrity": "sha1-XCi0KWqDYFvi4ZHY6+zQK4Smnww=",
       "requires": {
         "babel-runtime": "6.26.0",
         "btoa": "1.1.2",
+        "cookie": "0.3.1",
         "deep-extend": "0.4.2",
         "fast-json-patch": "1.1.8",
         "isomorphic-fetch": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "request": "^2.81.0"
   },
   "dependencies": {
-    "swagger-client": "3.2.x"
+    "swagger-client": "^3.3.1"
   }
 }


### PR DESCRIPTION
- reset package.json to accept later swagger-client versions
- apply() function needed to return `obj` instead of `true` for the load of swagger.json

This bug was introduced in https://github.com/IBM-Bluemix/gp-js-client/issues/70  because before https://github.com/swagger-api/swagger-js/pull/1161 it seems the requestInterceptor was not called for /swagger.json loads.

Fixes: https://github.com/IBM-Bluemix/gp-js-client/issues/104